### PR TITLE
renders dots & arrows with emphasis

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -10,7 +10,7 @@
 
     /* and I might only need this height because 
     cont body child doesn't have designated sizing */
-    height: 90vh;
+    height: 650px;
 
     display: flex;
     justify-content: center;

--- a/src/components/CardHolder/CardHolder.css
+++ b/src/components/CardHolder/CardHolder.css
@@ -1,7 +1,7 @@
 
 .card_cont {
     width: 100%;
-    height: 100%;
+    /* height: 740px; */
 
     display: flex;
     flex-direction: column;
@@ -22,8 +22,8 @@
     border: 1px solid white;
     border-radius: 5px;
 
-    height: calc(100% - 150px);
-    width: 100%;
+    height: 500px;
+    width: 450px;
 
     display: flex;
     justify-content: center;
@@ -31,8 +31,8 @@
 }
 
 .card_imgBody {
-    width: 100%;
-    height: 100%;
+    width: 450px;
+    height: 500px;
 
     display: flex;
     justify-content: center;
@@ -49,11 +49,11 @@
 .card_footer {
     /* border: 1px solid white; */
 
-    height: 100px;
+    /* height: 100px; */
     width: 100%;
     display: flex;
     flex-direction: column;
-    justify-content: space-between;
+    /* justify-content: space-between; */
     align-items: center;
 
 }
@@ -69,15 +69,15 @@
 }
 
 .buttons_btn {
-    height: 15px;
-    width: 15px;
-    background-color: rgba(255, 255, 255, 0.3);
+    height: 10px;
+    width: 10px;
+    background-color: rgba(255, 255, 255, 0.5);
     margin: 10px;
     border-radius: 50%;
 }
 
 .buttons_btn:hover {
-    background-color: rgba(255, 255, 255, 0.6);
+    background-color: rgba(255, 255, 255, 0.8);
     transform: scale(1.2);
 }
 

--- a/src/components/CardHolder/CardHolder.js
+++ b/src/components/CardHolder/CardHolder.js
@@ -1,16 +1,25 @@
 
 import './CardHolder.css'
-import React, { useEffect, useReducer } from 'react'
+import React, { useReducer } from 'react'
 
 import { Arrow } from '../../components'
 import ImgWrap from './ImgWrap/ImgWrap.js'
 
 import {
-
     initImg,
     IMG_ACTION,
     imgReducer,
 } from './assetBundle.js'
+
+const activeBtnUI = (cur, idx) => {
+
+    if (cur === idx) {return {
+        backgroundColor: "rgba(255, 255, 255, 1)",
+        transform: "scale(1.4)"
+    }} else return {}
+
+}
+// render as fn intaking current
 
 function CardHolder() {
 
@@ -28,9 +37,6 @@ return (
 <>
 
     <div className='card_cont'>
-        {/* <div className='card_header'>
-            <Arrow rotateProp={{ transform: 'rotate(-90deg)' }} />
-        </div> */}
         <div className='card_body'>
             <div className='card_imgBody'>
 
@@ -48,7 +54,8 @@ return (
             {
             [0, 1, 2, 3, 4].map((item, idx) => (
                 <div className='buttons_btn' key={idx}
-                
+                style={activeBtnUI(display.current, idx)}
+                // if current === idx, style should depict clear transform
                 ></div>
             ))
             }
@@ -56,9 +63,11 @@ return (
             <div className='arrows_cont'>
                 <Arrow 
                 rotateProp={{ transform: 'rotate(-90deg)' }} 
+                dir={'left'}
                 />
                 <Arrow 
                 rotateProp={{ transform: 'rotate(90deg)' }}
+                dir={'right'}
                 />
             </div>
         </div>

--- a/src/components/SVG/Arrow.js
+++ b/src/components/SVG/Arrow.js
@@ -1,17 +1,39 @@
 
 import './Arrow.css'
-import React from 'react'
+import React, { useState } from 'react'
 
-function Arrow({ rotateProp }) {
+const sWidth = (num) => num.toString()
+
+const sColorWhite = (emphasis) => {
+    return !emphasis 
+            ? 
+            "rgba(255, 255, 255, 0.6)"
+            :
+            emphasis > 0
+            ?
+            "rgba(255, 255, 255, 1)"
+            :
+            "rgba(255, 255, 255, 0.85)"
+}
+
+function Arrow({ rotateProp, dir }) {
+
+    const [emphasis, setEmphasis] = useState(0)
+
 return (
 <>
-    <svg className='arrow_SVG' height='50px' width='50px'
-    style={rotateProp}>
+    <svg className='arrow_SVG' height='25px' width='25px'
+    style={rotateProp}
+
+    onMouseDown={() => setEmphasis(1)}
+    onMouseUp={() => setEmphasis(-1)}
+    onMouseEnter={() => setEmphasis(-1)}
+    onMouseLeave={() => setEmphasis(0)}>
         <line x1='0%' y1="75%" x2="50%" y2="0%" 
-        stroke="white"
+        stroke={sColorWhite(emphasis)} strokeWidth={sWidth(emphasis ? 3.1 : 3)}
         />
         <line x1="50%" y1="0%" x2="100%" y2="75%" 
-        stroke="white"
+        stroke={sColorWhite(emphasis)} strokeWidth={sWidth(emphasis ? 2.1 : 2)}
         />
     </svg>
 </>

--- a/src/components/SVG/hoverReducer.js
+++ b/src/components/SVG/hoverReducer.js
@@ -1,0 +1,53 @@
+
+import produce from 'immer'
+
+const hoverInit = {
+    left: false,
+    right: false
+}
+
+const ACTION = {
+
+    HOVER_LEFT: 'hover_left_ljelrsje',
+    UNHOVER_LEFT: 'unhover_left_ljasl;ejr',
+
+    HOVER_RIGHT: 'hover_right_lajwerl;',
+    UNHOVER_RIGHT: 'unhover_right_lajewuh'
+
+}
+
+const hoverReducer = (state, {type, payload}) => {
+
+    switch(type) {
+
+        case ACTION.HOVER_LEFT:
+            return produce(state, draft => {
+                draft.left = true
+            })
+
+        case ACTION.UNHOVER_LEFT:
+            return produce(state, draft => {
+                draft.left = false
+            })
+
+        case ACTION.HOVER_RIGHT:
+            return produce(state, draft => {
+                draft.right = true
+            })
+
+        case ACTION.UNHOVER_RIGHT:
+            return produce(state, draft => {
+                draft.right = false
+            })
+
+        default:
+            return state
+    }
+}
+
+export {
+    hoverInit,
+    ACTION,
+    hoverReducer,
+    
+}


### PR DESCRIPTION
[x] - dots emphasize hover, selected, no-emphasis
[x] - arrows emphasize active*, hover, no-emphasis

active*: we imitate css' active with javascript by allowing both mouseUp & mouseLeave to perform a setState. mouseUp assumes user is still hovering so state is set to hover whereas leave will just de-emphasize the arrow